### PR TITLE
test: Use primary matcher names instead of alias functions

### DIFF
--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -85,14 +85,14 @@ describe('cli()', () => {
         stderr
       })
     ).toEqual(0)
-    expect(mockClient).toBeCalledWith({ auth: 'test-api-key-1' })
-    expect(mockBlockToHast).toBeCalledTimes(1)
+    expect(mockClient).toHaveBeenCalledWith({ auth: 'test-api-key-1' })
+    expect(mockBlockToHast).toHaveBeenCalledTimes(1)
     expect(mockBlockToHast.mock.calls[0][1]).toEqual({
       block_id: 'test-block-id-1',
       blocktoHastOpts: { defaultClassName: undefined },
       richTexttoHastOpts: { defaultClassName: undefined }
     })
-    expect(mockToHtml).toBeCalledTimes(0)
+    expect(mockToHtml).toHaveBeenCalledTimes(0)
     expect(outData).toEqual(`{
   "id": "test-1"
 }
@@ -116,14 +116,14 @@ describe('cli()', () => {
         stderr
       })
     ).toEqual(0)
-    expect(mockClient).toBeCalledWith({ auth: 'test-api-key-1' })
-    expect(mockBlockToHast).toBeCalledTimes(1)
+    expect(mockClient).toHaveBeenCalledWith({ auth: 'test-api-key-1' })
+    expect(mockBlockToHast).toHaveBeenCalledTimes(1)
     expect(mockBlockToHast.mock.calls[0][1]).toEqual({
       block_id: 'test-block-id-1',
       blocktoHastOpts: { defaultClassName: true },
       richTexttoHastOpts: { defaultClassName: true }
     })
-    expect(mockToHtml).toBeCalledTimes(0)
+    expect(mockToHtml).toHaveBeenCalledTimes(0)
     expect(outData).toEqual(`{
   "id": "test-1"
 }
@@ -147,15 +147,15 @@ describe('cli()', () => {
         stderr
       })
     ).toEqual(0)
-    expect(mockClient).toBeCalledWith({ auth: 'test-api-key-1' })
-    expect(mockBlockToHast).toBeCalledTimes(1)
+    expect(mockClient).toHaveBeenCalledWith({ auth: 'test-api-key-1' })
+    expect(mockBlockToHast).toHaveBeenCalledTimes(1)
     expect(mockBlockToHast.mock.calls[0][1]).toEqual({
       block_id: 'test-block-id-1',
       blocktoHastOpts: { defaultClassName: undefined },
       richTexttoHastOpts: { defaultClassName: undefined }
     })
-    expect(mockToHtml).toBeCalledTimes(1)
-    expect(mockToHtml).toBeCalledWith({
+    expect(mockToHtml).toHaveBeenCalledTimes(1)
+    expect(mockToHtml).toHaveBeenCalledWith({
       id: 'test-1'
     })
     expect(outData).toEqual('test-html-1\n')

--- a/test/lib/block.spec.ts
+++ b/test/lib/block.spec.ts
@@ -57,8 +57,8 @@ describe('BlockItem class', () => {
     const client = { listBlockChildren: mockList }
     const i = new BlockItem(client as any, { block_id: 'test-id-1' })
     await i.init()
-    expect(mockList).toBeCalledTimes(1)
-    expect(mockList).toBeCalledWith({ block_id: 'test-id-1' })
+    expect(mockList).toHaveBeenCalledTimes(1)
+    expect(mockList).toHaveBeenCalledWith({ block_id: 'test-id-1' })
   })
   it('should iterate block item', async () => {
     const mockBlocks = [
@@ -104,9 +104,9 @@ describe('BlockItem class', () => {
     expect(await i.block()).toEqual(mockBlocks2[1])
     expect(await i.block()).toBeNull()
 
-    expect(mockList).toBeCalledTimes(2)
-    expect(mockList).toBeCalledWith({ block_id: 'test-id-1' })
-    expect(mockList).toBeCalledWith({
+    expect(mockList).toHaveBeenCalledTimes(2)
+    expect(mockList).toHaveBeenCalledWith({ block_id: 'test-id-1' })
+    expect(mockList).toHaveBeenCalledWith({
       block_id: 'test-id-1',
       start_cursor: 'cursor1'
     })


### PR DESCRIPTION
https://jestjs.io/docs/upgrading-to-jest30
